### PR TITLE
Update package.json to include pnpm package manager version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,6 @@
     "crypto": "^1.0.1",
     "express": "^4.21.1",
     "prettier": "^3.4.1"
-  }
+  },
+  "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c"
 }


### PR DESCRIPTION
- Added "packageManager" entry to package.json specifying pnpm version 9.15.0.
- This change ensures clarity on the package manager used for the project and aligns with recent updates to pnpm.

